### PR TITLE
output variables line by line

### DIFF
--- a/lib/capistrano/dotenv/tasks.rb
+++ b/lib/capistrano/dotenv/tasks.rb
@@ -14,7 +14,11 @@ namespace :config do
     dotenv_path = fetch(:capistrano_dotenv_path_escaped)
 
     on roles(fetch(:capistrano_dotenv_role)) do
-      info capture(:cat, dotenv_path) if test fetch(:capistrano_dotenv_path_exists)
+      if test fetch(:capistrano_dotenv_path_exists)
+        capture(:cat, dotenv_path).each_line do |line|
+          info line
+        end
+      end
     end
   end
 


### PR DESCRIPTION
when using airbrussh for log formatting (which will be the default in
Capistrano 3.5), the output gets truncated.
this makes sure the full variables are shown (to some extend)
<table><tr><th>Before</th><th>After</th></tr><tr><td>![image](https://cloud.githubusercontent.com/assets/351038/14042428/31b0d3dc-f27a-11e5-94c7-d5e77927cbf1.png)</td><td>![image](https://cloud.githubusercontent.com/assets/351038/14042490/ae390578-f27a-11e5-8983-24f02a9696b1.png)</td></tr><table>
