### PR TITLE
make use of rake task arguments for passing keys to remove

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,16 +35,22 @@ Then use it from the `cap` command.
 $ cap production config:show
 ```
 
-### Create / Update a variable
+### Set (create or update) a variable
 
 ```
 $ cap production config:set VARNAME=value
 ```
 
-### Delete a variable
+### Remove a variable
 
 ```
-$ cap production config:remove key=VARNAME
+$ cap production config:remove[VARNAME]
+```
+
+Or multiple at once:
+
+```
+$ cap production config:remove[VARNAME1,VARNAME2]
 ```
 
 ## Contributing

--- a/lib/capistrano/dotenv/tasks.rb
+++ b/lib/capistrano/dotenv/tasks.rb
@@ -38,17 +38,18 @@ namespace :config do
 
   desc "Removes an environment variable from the .env config file"
   task :remove do |t, args|
-    unless ENV['key']
-      raise "You need to set `key=KEY_TO_BE_REMOVED` to remove a key"
-    end
-
     dotenv_path = fetch(:capistrano_dotenv_path_escaped)
 
     on roles(fetch(:capistrano_dotenv_role)) do
       contents = capture(:cat, dotenv_path) if test fetch(:capistrano_dotenv_path_exists)
       config = Capistrano::Dotenv::Config.new(contents)
 
-      config.remove(ENV['key'])
+      if ENV['key']
+        $stderr.puts "DEPRECATION WARNING: Using `key=KEY_TO_BE_REMOVED` is deprecated, just pass the keys as arguments to the task; `config:remove[KEY_A,KEY_B]`"
+        config.remove(ENV['key'])
+      else
+        config.remove(*args.extras)
+      end
       upload!(config.to_io, dotenv_path)
     end
   end


### PR DESCRIPTION
Using an environment variable is non-standard, and because rake has task-argument support, I think this is a nicer solution:

So instead of 

```
cap production config:remove key=SOME_KEY
```

You now do:

```
cap production config:remove[SOME_KEY]
```

And it is now also possible to remove multiple keys at once:

```
cap production config:remove[SOME_KEY,ANOTHER_KEY]
```

I left the old `key=KEY_TO_DELETE` support in with a deprecation warning.
