### PR TITLE
Allow dot env filename to be overridden

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ Or multiple at once:
 $ cap production config:remove[VARNAME1,VARNAME2]
 ```
 
+## Configuration
+
+Set the env file for a given environment by adding the following line to your `config/deploy/staging.rb` script:
+```ruby
+set :capistrano_dotenv_file, -> { '.env.staging' }
+```
+
+
 ## Contributing
 
 1. Fork it ( https://github.com/glyph-fr/capistrano-dotenv-tasks/fork )

--- a/lib/capistrano/dotenv/tasks.rb
+++ b/lib/capistrano/dotenv/tasks.rb
@@ -4,7 +4,8 @@ require "capistrano/dotenv/config"
 require 'shellwords'
 
 set :capistrano_dotenv_role, -> { :app }
-set :capistrano_dotenv_path, -> { shared_path.join('.env') }
+set :capistrano_dotenv_file, -> { '.env' }
+set :capistrano_dotenv_path, -> { shared_path.join(fetch(:capistrano_dotenv_file)) }
 set :capistrano_dotenv_path_escaped, -> {fetch(:capistrano_dotenv_path).to_s.shellescape }
 set :capistrano_dotenv_path_exists, -> { "[ -f #{fetch(:capistrano_dotenv_path_escaped)} ]" }
 


### PR DESCRIPTION
### Things Done:
- Added dot env file name as a var to support using a different env file in different environments.
- Updated readme with some config notes.